### PR TITLE
add Makefile with venv, formatter and linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,50 @@
+################################################################
+# GLOBALS													   #
+################################################################
+
+PROJECT_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+PROJECT_NAME := hearai
+PYTHON ?= python3
+VENV = $(PROJECT_DIR)/.venv
+PIP = $(VENV)/bin/pip
+VIRTUALENV = $(PYTHON) -m venv
+SHELL=/bin/bash
+
+################################################################
+# VIRTUAL ENVIRONMENT AND DEPENDENCIES						   #
+################################################################
+
+.PHONY: venv
+## create virtual environment
+venv: ./.venv/.requirements
+        
+.venv:
+		$(VIRTUALENV) $(VENV)
+		$(PIP) install -U pip setuptools wheel
+
+.venv/.requirements: .venv
+		$(PIP) install -r $(PROJECT_DIR)/requirements.txt -r $(PROJECT_DIR)/requirements-dev.txt
+		touch $(VENV)/.requirements
+
+.PHONY: venv-clean
+## clean virtual environment
+venv-clean:
+		rm -rf $(VENV)
+
+################################################################
+# style														   #
+################################################################
+
+.PHONY: format-check
+## check the code style
+format-check: .venv/.requirements
+		$(VENV)/bin/black --check $(PROJECT_DIR)/
+
+.PHONY: format-apply
+## reformat the code style
+format-apply: venv
+		$(VENV)/bin/black $(PROJECT_DIR)/
+
+.PHONY: lint
+lint: venv
+		@PYTHONPATH=$(PYTHONPATH):$(PROJECT_DIR) $(VENV)/bin/pylint --rcfile=setup.cfg train.py $(PROJECT_DIR)/models/

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+black==19.10b0
+pylint
+flake8==3.8.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[pylint]
+output-format =  colorized
+reports = yes
+score = yes
+max-line-length = 88


### PR DESCRIPTION
Adding Makefile with:
- venv so everyone can work in the same environment (and it will be easier to add tests)
- requirements-dev
- formatter (back is chosen, we can change it in the future if someone has good reason)
- linter (pylint with flake8)