### PR TITLE
add loading multiple datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,14 +53,14 @@ Pipeline handle multihead classification. We predefine `classification_heads` fo
 Hamburg Sign Language Notation System (HamNoSys) is a gesture transcription alphabetic system that describes the symbols and gestures such as hand shape, hand location, and movement. Read more about HamNoSys [here - Introduction to HamNoSys](https://www.hearai.pl/post/4-hamnosys/) and [here - Introduction to HamNoSys Part 2](https://www.hearai.pl/post/5-hamnosys2/). HamNoSys always have the same number of possible classes.
 
 ```
-"symmetry_operator": 12,
-"hand_shape_base_form": 13,
+"symmetry_operator": 9,
+"hand_shape_base_form": 12,
 "hand_shape_thumb_position": 4,
 "hand_shape_bending": 6,
 "hand_position_finger_direction": 18,
 "hand_position_palm_orientation": 8,
-"hand_location_frontal_plane_LR": 5,
-"hand_location_frontal_plane_TB": 36,
+"hand_location_x": 5,
+"hand_location_y": 37,
 ```
 
 Gloss is an annotation system that applies a label (a word) to the sign. Number glosses depend on a language and dataset. It is usually a bigger number as it must define as many words (glosses) as possible.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,15 @@ When you install a new library, please add it to the list in `requirements.txt` 
 
 # 🏁 Example train.py run
 
+Run with a single dataset:
+
 `python3 train.py --data "/dih4/dih4_2/hearai/data/frames/pjm" --epochs 100 --lr 1e-4 --classification-mode "hamnosys" --neptune --num_segments 16 --b 4 --workers 16 --gpu 1`
+
+Run with multiple datasets (list datasets paths separated with spaces)
+
+`python3 train.py --data "/dih4/dih4_2/hearai/data/frames/pjm" "/dih4/dih4_2/hearai/data/frames/basic_lexicon" --epochs 100 --lr 1e-4 --classification-mode "hamnosys" --neptune --num_segments 16 --b 4 --workers 0 --gpu 1`
+
+
 
 
 # 🎨 Style

--- a/README.md
+++ b/README.md
@@ -27,9 +27,21 @@ The transformer is a widely-used deep learning model that adopts the mechanism o
 ## 📑 [WiP] Datasets
 In our studies we are using PJM lexicon with annotations provided at our internal server at:
 - directories with frames: `/dih4/dih4_2/hearai/data/frames/pjm/`
-- HamNoSys annotation file: `/dih4/dih4_2/hearai/data/frames/pjm/test_hamnosys2.txt` - 8 heads only [WiP]
+- HamNoSys annotation file: `/dih4/dih4_2/hearai/data/frames/pjm/test_hamnosys.txt` - 8 heads only [WiP]
 - glosses annotation file: `/dih4/dih4_2/hearai/data/frames/pjm/test_gloss2.txt`
 - landmarks directory: `/dih4/dih4_2/hearai/data/#mediapipe_landmarks/korpus/labeled/`
+
+To load multiple datasets simply pass to ```args.parser``` list of datasets (file paths to video separated with spaces). We have possibility to load these datasets:
+- pjm: /dih4/dih4_2/hearai/data/frames/pjm
+- basic_lexicon: /dih4/dih4_2/hearai/data/frames/basic_lexicon
+- galex: /dih4/dih4_2/hearai/data/frames/galex
+- glex: /dih4/dih4_2/hearai/data/frames/glex
+
+```python
+python3 train.py --data "/dih4/dih4_2/hearai/data/frames/pjm" "/dih4/dih4_2/hearai/data/frames/basic_lexicon" --epochs 100 --lr 1e-4 --classification-mode "hamnosys" --neptune --num_segments 16 --b 4 --workers 0 --gpu 1
+```
+
+Attention! The method requires that all ```annotation_files``` have exactly the same annotation filename e.g. ```"test_hamnosys.txt"```! If you need to pass different path you need to do it manually.
 
 Dataloader gives possibility to load data:
 - choosing number of frames by setting `--num_segments` variable (in this option `--time` argument is set to `None` as default)
@@ -40,15 +52,15 @@ Pipeline handle multihead classification. We predefine `classification_heads` fo
 
 Hamburg Sign Language Notation System (HamNoSys) is a gesture transcription alphabetic system that describes the symbols and gestures such as hand shape, hand location, and movement. Read more about HamNoSys [here - Introduction to HamNoSys](https://www.hearai.pl/post/4-hamnosys/) and [here - Introduction to HamNoSys Part 2](https://www.hearai.pl/post/5-hamnosys2/). HamNoSys always have the same number of possible classes.
 
-
 ```
-"hand_shape_base_form": 6,
-"hand_shape_thumb_position": 3,
-"hand_shape_bending": 4,
+"symmetry_operator": 12,
+"hand_shape_base_form": 13,
+"hand_shape_thumb_position": 4,
+"hand_shape_bending": 6,
 "hand_position_finger_direction": 18,
 "hand_position_palm_orientation": 8,
-"hand_location_x": 14,
-"hand_location_y": 5,
+"hand_location_frontal_plane_LR": 5,
+"hand_location_frontal_plane_TB": 36,
 ```
 
 Gloss is an annotation system that applies a label (a word) to the sign. Number glosses depend on a language and dataset. It is usually a bigger number as it must define as many words (glosses) as possible.

--- a/datasets/dataset.py
+++ b/datasets/dataset.py
@@ -20,6 +20,14 @@ if sys.version[0] == "2":
     reload(sys)
     sys.setdefaultencoding("utf-8")
 
+ALL_HAMNOSYS_HEADS = {"symmetry_operator": 3,
+            "hand_shape_base_form": 4,
+            "hand_shape_thumb_position": 5,
+            "hand_shape_bending": 6,
+            "hand_position_finger_direction": 7,
+            "hand_position_palm_orientation": 8,
+            "hand_location_x": 9,
+            "hand_location_y": 10}
 
 class VideoRecord(object):
     """
@@ -38,9 +46,10 @@ class VideoRecord(object):
              5) any following elements are labels in the case of multi label provided.
     """
 
-    def __init__(self, row, root_datapath, landmarks_path=None):
+    def __init__(self, row, root_datapath, num_classes_dict, landmarks_path=None):
         self._data = row
         self._path = os.path.join(root_datapath, row[0])
+        self.num_classes_dict = num_classes_dict
         try:
             with open(
                 os.path.join(landmarks_path, row[0] + "_properties.json"), "r"
@@ -70,11 +79,14 @@ class VideoRecord(object):
     @property
     def label(self) -> Union[str, List[str]]:
         # just one label as gloss
-        if len(self._data) == 4:
+        id_list = []
+        for key in self.num_classes_dict.keys():
+            id_list.append(self._data[ALL_HAMNOSYS_HEADS[key]])
+        if "gloss" in self.num_classes_dict.keys():
             return int(self._data[3])
         # Sample associated with multiple labels - HamNoSys
         else:
-            return [int(label) for label in self._data[3:]]
+            return [int(label) for label in id_list]
 
 
 class VideoFrameDataset(torch.utils.data.Dataset):
@@ -136,10 +148,11 @@ class VideoFrameDataset(torch.utils.data.Dataset):
         self.landmarks_path = landmarks_path
         self.transform = transform
         self.test_mode = test_mode
+        self.num_classes_dict = create_heads_dict(classification_mode)
 
         self._parse_annotationfile()
         self._sanity_check_samples()
-        self.num_classes_dict = create_heads_dict(classification_mode)
+        
 
     def _load_image(self, directory: str, idx: int) -> Image.Image:
         return Image.open(
@@ -151,7 +164,8 @@ class VideoFrameDataset(torch.utils.data.Dataset):
 
     def _parse_annotationfile(self):
         self.video_list = [
-            VideoRecord(x.strip().split(), self.root_path, self.landmarks_path)
+            VideoRecord(x.strip().split(), self.root_path,
+                        self.num_classes_dict, self.landmarks_path)
             for x in open(self.annotationfile_path)
         ]
 

--- a/datasets/dataset.py
+++ b/datasets/dataset.py
@@ -79,13 +79,13 @@ class VideoRecord(object):
     @property
     def label(self) -> Union[str, List[str]]:
         # just one label as gloss
-        id_list = []
-        for key in self.num_classes_dict.keys():
-            id_list.append(self._data[ALL_HAMNOSYS_HEADS[key]])
         if "gloss" in self.num_classes_dict.keys():
             return int(self._data[3])
         # Sample associated with multiple labels - HamNoSys
         else:
+            id_list = []
+            for key in self.num_classes_dict.keys():
+                id_list.append(self._data[ALL_HAMNOSYS_HEADS[key]])
             return [int(label) for label in id_list]
 
 

--- a/datasets/dataset.py
+++ b/datasets/dataset.py
@@ -178,7 +178,7 @@ class VideoFrameDataset(torch.utils.data.Dataset):
             )
 
         for id, record in enumerate(self.video_list):
-            if any(not x.isdigit() for x in record._data):
+            if any(not x.isdigit() for x in record._data[1:]):
                 # Found datafile header. Removing it.
                 del self.video_list[id]
                 continue

--- a/models/feature_extractors/cnn_extrator.py
+++ b/models/feature_extractors/cnn_extrator.py
@@ -6,7 +6,7 @@ class CnnExtractor(nn.Module):
     """Basic timm model"""
 
     def __init__(
-        self, representation_size=128, model_path="efficientnet_b1", device="cpu"
+        self, representation_size=128, model_path="efficientnet_b1"
     ):
         """
         Dummy example of __init__ function of basic timm model. Simply loads a timm model and does nothing else.
@@ -21,9 +21,8 @@ class CnnExtractor(nn.Module):
         self.model = timm.create_model(
             model_path, pretrained=True, num_classes=representation_size
         )
-        self.__device = device
         # this is a dummy example but in practice this will be longer
 
     def forward(self, input, **kwargs):
         # this is a dummy example but in practice this will be longer
-        return self.model(input.to(self.__device))
+        return self.model(input)

--- a/models/model.py
+++ b/models/model.py
@@ -46,7 +46,6 @@ class GlossTranslationModel(pl.LightningModule):
         transformer_name="fake_transformer",
         model_save_dir="",
         neptune=False,
-        device="cpu",
     ):
         super().__init__()
 
@@ -62,7 +61,7 @@ class GlossTranslationModel(pl.LightningModule):
         self.warmup_steps = warmup_steps
         self.multiply_lr_step = multiply_lr_step
         self.num_classes_dict = create_heads_dict(classification_mode)
-
+        
         # losses
         self.summary_loss = SummaryLoss(nn.CrossEntropyLoss)
 
@@ -71,7 +70,6 @@ class GlossTranslationModel(pl.LightningModule):
         self.feature_extractor = self.model_loader.load_feature_extractor(
             feature_extractor_name,
             representation_size,
-            device=device,
             model_path=feature_extractor_model_path,
         )
         self.multi_frame_feature_extractor = MultiFrameFeatureExtractor(
@@ -86,7 +84,6 @@ class GlossTranslationModel(pl.LightningModule):
                 num_encoder_layers,
                 num_segments,
                 num_attention_heads,
-                device=device
             )
         else:
             self.transformer = self.model_loader.load_transformer(
@@ -99,7 +96,7 @@ class GlossTranslationModel(pl.LightningModule):
 
     def forward(self, input, **kwargs):
         predictions = []
-        x = self.multi_frame_feature_extractor(input)
+        x = self.multi_frame_feature_extractor(input.to(self.device))
         x = self.transformer(x)
         for head in self.cls_head:
             predictions.append(head(x.cpu()))

--- a/models/transformers/hubert_transformer.py
+++ b/models/transformers/hubert_transformer.py
@@ -29,7 +29,7 @@ class HubertTransformer(nn.Module):
         """
         super(HubertTransformer, self).__init__()
         configuration = HubertConfig()
-        self.model = HubertModel(configuration)
+        self.model = HubertModel(configuration,)
         self._input_features = input_features
         self._output_features = output_features
 

--- a/models/transformers/sign_language_transformer.py
+++ b/models/transformers/sign_language_transformer.py
@@ -54,7 +54,7 @@ class SignLanguageTransformer(nn.Module):
 
     def forward(self, input: torch.Tensor):
         # Positional Encoding Start
-        positional_encoding = input + self._position_encoding[:, : input.shape[1]]
+        positional_encoding = input + self._position_encoding[:, : input.shape[1]].to(input.device)
 
         x = self._dropout_positional_encoding(positional_encoding)
         # Positional Encoding End

--- a/models/transformers/sign_language_transformer.py
+++ b/models/transformers/sign_language_transformer.py
@@ -21,7 +21,6 @@ class SignLanguageTransformer(nn.Module):
         num_frames: int = 8,
         num_attention_heads: int = 8,
         dropout_rate: float = 0.1,
-        device="cpu",
     ):
         """
         Args:
@@ -43,7 +42,6 @@ class SignLanguageTransformer(nn.Module):
                     feedforward_size=feedforward_size,
                     num_attention_heads=num_attention_heads,
                     dropout_rate=dropout_rate,
-                    device=device,
                 )
                 for _ in range(num_encoder_layers)
             ]
@@ -51,13 +49,12 @@ class SignLanguageTransformer(nn.Module):
         self._dropout_positional_encoding = nn.Dropout(dropout_rate)
         self._last_norm = nn.LayerNorm(input_size)
         self._last_linear = nn.Linear(num_frames * input_size, output_size)
-        self.__device = device
 
         self._position_encoding = self.__get_position_encoding()
 
     def forward(self, input: torch.Tensor):
         # Positional Encoding Start
-        positional_encoding = input.to(self.__device) + self._position_encoding[:, : input.shape[1]].to(self.__device)
+        positional_encoding = input + self._position_encoding[:, : input.shape[1]]
 
         x = self._dropout_positional_encoding(positional_encoding)
         # Positional Encoding End
@@ -95,7 +92,6 @@ class SLRTEncoder(nn.Module):
         feedforward_size: int,
         num_attention_heads: int,
         dropout_rate: float,
-        device: str = "cpu",
     ):
         """
         Args:
@@ -123,14 +119,11 @@ class SLRTEncoder(nn.Module):
             nn.Dropout(dropout_rate),
         )
 
-        self.__device = device
+
 
     def forward(self, input: torch.Tensor):
 
-        positional_encoding_normalized = self._positional_encoding_norm(input).to(
-            self.__device
-        )
-
+        positional_encoding_normalized = self._positional_encoding_norm(input)
         # Self Attention (Multi-Head Attention) Start
         values = positional_encoding_normalized
         keys = positional_encoding_normalized

--- a/train.py
+++ b/train.py
@@ -189,7 +189,7 @@ def main(args):
 
     trainer = pl.Trainer(
         max_epochs=args.epochs,
-        val_check_interval=args.ratio,
+        val_check_interval=1.0,
         gpus=args.gpu if args.gpu > -1 else None,
         progress_bar_refresh_rate=10,
         accumulate_grad_batches=1,

--- a/train.py
+++ b/train.py
@@ -30,7 +30,7 @@ def get_args_parser():
     parser.add_argument(
         "--classification-mode",
         default="hamnosys",
-        choices=["gloss", "hamnosys"],
+        choices=["gloss", "hamnosys", "hamnosys-less"],
         help="mode for classification, choose from classification_mode.py",
     )
     parser.add_argument(
@@ -128,7 +128,7 @@ def main(args):
     for video_root in videos_root:
         if args.classification_mode == "gloss":
             annotation_file = os.path.join(video_root, "test_gloss.txt")
-        elif args.classification_mode == "hamnosys":
+        elif "hamnosys" in args.classification_mode:
             annotation_file = os.path.join(video_root, "test_hamnosys.txt")
 
         dataset = VideoFrameDataset(

--- a/train.py
+++ b/train.py
@@ -101,7 +101,7 @@ def get_args_parser():
 
 def main(args):
     # set GPU to use
-    if args.gpu > 0:
+    if args.gpu > -1:
         os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
         os.environ["CUDA_VISIBLE_DEVICES"] = str(args.gpu)
         os.environ["TOKENIZERS_PARALLELISM"] = "true"
@@ -180,7 +180,6 @@ def main(args):
         num_segments=args.num_segments,
         model_save_dir=args.save,
         neptune=args.neptune,
-        device="cuda:0" if args.gpu > 0 else "cpu",
         representation_size=512,
         feedforward_size=1024,
         transformer_output_size=784,
@@ -191,7 +190,7 @@ def main(args):
     trainer = pl.Trainer(
         max_epochs=args.epochs,
         val_check_interval=args.ratio,
-        gpus=args.gpu if args.gpu > 0 else None,
+        gpus=args.gpu if args.gpu > -1 else None,
         progress_bar_refresh_rate=10,
         accumulate_grad_batches=1,
         fast_dev_run=args.fast_dev_run,

--- a/utils/classification_mode.py
+++ b/utils/classification_mode.py
@@ -6,14 +6,14 @@ def create_heads_dict(classification_mode):
         num_classes_dict = {"gloss": 2400}  # number of classes for each head
     elif classification_mode == "hamnosys":
         num_classes_dict = {
-            "symmetry_operator": 12,
-            "hand_shape_base_form": 13,
+            "symmetry_operator": 9,
+            "hand_shape_base_form": 12,
             "hand_shape_thumb_position": 4,
             "hand_shape_bending": 6,
             "hand_position_finger_direction": 18,
             "hand_position_palm_orientation": 8,
             "hand_location_x": 5,
-            "hand_location_y": 36,
+            "hand_location_y": 37,
         }  # number of classes for each head
     else:
         sys.exit("Wrong classification_mode passed to pipeline")

--- a/utils/classification_mode.py
+++ b/utils/classification_mode.py
@@ -15,6 +15,11 @@ def create_heads_dict(classification_mode):
             "hand_location_x": 5,
             "hand_location_y": 37,
         }  # number of classes for each head
+    elif classification_mode == "hamnosys-less":
+        num_classes_dict = {
+            "hand_shape_base_form": 12,
+            "hand_shape_thumb_position": 4,
+        }  # number of classes for each head
     else:
         sys.exit("Wrong classification_mode passed to pipeline")
 


### PR DESCRIPTION
Add option to load multiple datasets.
To load multiple datasets simply pass to `args.parser` list of datasets (file paths to videos separated with spaces)

`python3 train.py --data "/dih4/dih4_2/hearai/data/frames/pjm" "/dih4/dih4_2/hearai/data/frames/basic_lexicon" --epochs 100 --lr 1e-4 --classification-mode "hamnosys" --neptune --num_segments 16 --b 4 --workers 0 --gpu 1`

Attention! The method requires that all `annotation_file`s have exactly the same annotation filename e.g. `"test_hamnosys.txt"`! If you need to pass different path you need to do it manually.