### PR TITLE
Revert "GPU MisconfigurationException fix"

### DIFF
--- a/train.py
+++ b/train.py
@@ -118,6 +118,7 @@ def main(args):
     # set GPU to use
     if args.gpu > -1:
         os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
+        os.environ["CUDA_VISIBLE_DEVICES"] = str(args.gpu)
         os.environ["TOKENIZERS_PARALLELISM"] = "true"
 
     # set the seed for reproducibility

--- a/train.py
+++ b/train.py
@@ -221,7 +221,7 @@ def main(args):
     trainer = pl.Trainer(
         max_epochs=args.epochs,
         val_check_interval=1.0,
-        gpus=[args.gpu] if args.gpu > -1 else None,
+        gpus=[0] if args.gpu > -1 else None,
         progress_bar_refresh_rate=10,
         accumulate_grad_batches=1,
         fast_dev_run=args.fast_dev_run,


### PR DESCRIPTION
Reverts hearai/hearai#61.
THIS IS NOT A BUG! Without it Pytorch Lightning might spawn processes on GPU 0!
Please always use args.parser to pass GPU number!